### PR TITLE
Updates timestamps of edited karaoke and adds support for dead links

### DIFF
--- a/pages/karaoke.js
+++ b/pages/karaoke.js
@@ -106,7 +106,9 @@ export default class KaraokeApp extends React.Component {
                     {searchResults.map((s, i) => (
                         <tr key={i}>
                             <td>{i+1}.</td>
-                            <td><a href={songUrl(s.karaoke, s)} target="_blank" rel="noreferrer">{s.title} - {s.artist}</a></td>
+                            {s.dead 
+                            && <td className={styles.deadlink}>{s.title} - {s.artist}</td>
+                            || <td><a href={songUrl(s.karaoke, s)} target="_blank" rel="noreferrer">{s.title} - {s.artist}</a></td>}
                             <td>{formatDate(s.karaoke.date)} -{s.karaoke.title}</td>
 
                         </tr>
@@ -133,7 +135,9 @@ export default class KaraokeApp extends React.Component {
                         {k.songs.map((s, i) => (
                             <tr key={i}>
                                 <td>{i+1}.</td>
-                                <td style={{borderRight: 'none'}}><a href={songUrl(k, s)} target="_blank" rel="noreferrer">{s.title}{s.artist.length > 0 ? ' - ' : ''}{s.artist}</a></td>
+                                {s.dead 
+                                && <td style={{borderRight: 'none'}} className={styles.deadlink}>{s.title}{s.artist.length > 0 ? ' - ' : ''}{s.artist}</td>
+                                || <td style={{borderRight: 'none'}}><a href={songUrl(k, s)} target="_blank" rel="noreferrer">{s.title}{s.artist.length > 0 ? ' - ' : ''}{s.artist}</a></td>}
                                 <td style={{borderLeft: 'none'}}>&nbsp;</td>
 
                             </tr>

--- a/server/karaoke_data.js
+++ b/server/karaoke_data.js
@@ -1273,7 +1273,7 @@ let data = {
                     timestamp: "44m22s",
                     title: "ヒバナ (Match) /  (w.アイリス / IRyS)",
                     artist: "DECO*27",
-                    keywords: "hibana match tokino sora irys"
+                    keywords: "hibana match tokino sora irys deco27 deco 27 duet"
                 }
             ]
         },
@@ -1316,46 +1316,48 @@ let data = {
                     timestamp: "51m19s",
                     title: "Anna ni Issho Datta no ni (あんなに一緒だったのに)",
                     artist: "See-Saw",
-                    keywords: "anna ni issho datta no ni see saw"
+                    keywords: "anna ni issho datta no ni see saw",
+                    dead: true
                 },
                 {
                     timestamp: "59m03s",
                     title: "INVOKE",
                     artist: "T.M.Revolution",
-                    keywords: "invoke tm revolution"
+                    keywords: "invoke tm revolution",
+                    dead: true
                 },
                 {
-                    timestamp: "1h09m34s",
+                    timestamp: "54m29s",
                     title: "Sorairo Days (空色デイズ)",
                     artist: "Shoko Nakagawa",
                     keywords: "sorairo days shoko nakagawa"
                 },
                 {
-                    timestamp: "1h18m32s",
+                    timestamp: "1h03m26s",
                     title: "Shangri-La",
                     artist: "Angela",
                     keywords: "shangri la angela"
                 },
                 {
-                    timestamp: "1h28m26s",
+                    timestamp: "1h13m21s",
                     title: "Ikanaide",
                     artist: "Sohta",
                     keywords: "ikanaide sohta"
                 },
                 {
-                    timestamp: "1h35m37s",
+                    timestamp: "1h20m33s",
                     title: "Irony",
                     artist: "Majiko",
                     keywords: "irony majiko"
                 },
                 {
-                    timestamp: "1h43m44s",
+                    timestamp: "1h28m39s",
                     title: "I Beg You",
                     artist: "Aimer",
                     keywords: "i beg you aimer"
                 },
                 {
-                    timestamp: "1h53m33s",
+                    timestamp: "1h38m30s",
                     title: "VIOLET (TV Size)",
                     artist: "Ninomae Ina'nis",
                     keywords: "violet ninomae ina nis"

--- a/styles/Karaoke.module.css
+++ b/styles/Karaoke.module.css
@@ -25,6 +25,10 @@
     font-weight: bold;
     background-color: #ffffff;
 }
+.deadlink {
+    text-decoration: line-through;
+    color: #999
+}
 
 .site table {
     margin-top: 10px;


### PR DESCRIPTION
- Updates timestamps of the edited May 20 "【KARAOKE】Let's sing baby" karaoke
- Adds support for dead links. The song will show up without a timestamp and with strike-through text to indicate it was cut.
- Minor change to the Hibana keywords to be consistent with the other deco*27 songs